### PR TITLE
removed hardcoded RSV version

### DIFF
--- a/src/handlers/logic/settings/versions.py
+++ b/src/handlers/logic/settings/versions.py
@@ -75,7 +75,7 @@ def get_version(user):
         if "version" in results[0]:
             return results[0]["version"]
 
-    return "RSV"
+    return None
 
 
 def get_guild_version(guild):
@@ -87,7 +87,7 @@ def get_guild_version(guild):
             if "version" in results[0]:
                 return results[0]["version"]
 
-        return "RSV"
+        return None
 
 
 def get_versions():


### PR DESCRIPTION
removed hardcoded RSV version in favor of returning a NoneType. I think this is what the author may have intended.